### PR TITLE
Fix missing abort signal on HackerNews item fetch

### DIFF
--- a/src/services/hackernews/hooks/useGetItems.ts
+++ b/src/services/hackernews/hooks/useGetItems.ts
@@ -1,4 +1,4 @@
-import { useQueries, useQuery } from '@tanstack/react-query'
+import { useQueries } from '@tanstack/react-query'
 import { HackerNewsQueryKeys } from '../queryKeys'
 import { getItem } from 'services/hackernews'
 import { HackerNewsItem } from '../types'

--- a/src/services/hackernews/index.ts
+++ b/src/services/hackernews/index.ts
@@ -15,7 +15,9 @@ export const getItem = async (
     itemId: string,
     signal?: AbortSignal
 ): Promise<HackerNewsItem> => {
-    const { data } = await api.get<HackerNewsItem>(`/v0/item/${itemId}.json`)
+    const { data } = await api.get<HackerNewsItem>(`/v0/item/${itemId}.json`, {
+        signal,
+    })
 
     return data
 }


### PR DESCRIPTION
## Summary
- pass AbortSignal to `getItem` when querying HackerNews API
- clean up unused import in `useGetItems` hook

## Testing
- `npm test --silent`
- `npm run build --silent` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_685d6d6fff9c8324a10eb12e8a24914c